### PR TITLE
Don't fail analyze on deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Import Sorter Check
         run: dart run import_sorter:main --no-comments --exit-if-changed
       - name: Dart Analyze Check
-        run: flutter analyze
+        run: flutter analyze --fatal-infos=false
 
   build-for-android:
     name: Build for Flutter Android

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Import Sorter Check
         run: dart run import_sorter:main --no-comments --exit-if-changed
       - name: Dart Analyze Check
-        run: flutter analyze --fatal-infos=false
+        run: flutter analyze --no-fatal-infos
 
   build-for-android:
     name: Build for Flutter Android

--- a/lib/src/ui/widgets/participant/participant_status_bar.dart
+++ b/lib/src/ui/widgets/participant/participant_status_bar.dart
@@ -49,7 +49,7 @@ class ParticipantStatusBar extends StatelessWidget {
         var isScreenShare = trackCtx?.isScreenShare ?? false;
         return Container(
           padding: const EdgeInsets.symmetric(horizontal: 6),
-          color: Colors.black.withValues(alpha: 0.6),
+          color: Colors.black.withOpacity(0.6),
           child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
               crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/src/ui/widgets/room/camera_switch_button.dart
+++ b/lib/src/ui/widgets/room/camera_switch_button.dart
@@ -33,7 +33,7 @@ class CameraSwitchButton extends StatelessWidget {
     return ElevatedButton(
       style: ButtonStyle(
         backgroundColor:
-            WidgetStateProperty.all(Colors.grey.withValues(alpha: 0.9)),
+            WidgetStateProperty.all(Colors.grey.withOpacity(0.9)),
         foregroundColor: WidgetStateProperty.all(Colors.white),
         overlayColor: WidgetStateProperty.all(Colors.grey),
         shape: WidgetStateProperty.all(const RoundedRectangleBorder(

--- a/lib/src/ui/widgets/room/camera_switch_button.dart
+++ b/lib/src/ui/widgets/room/camera_switch_button.dart
@@ -32,8 +32,7 @@ class CameraSwitchButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       style: ButtonStyle(
-        backgroundColor:
-            WidgetStateProperty.all(Colors.grey.withOpacity(0.9)),
+        backgroundColor: WidgetStateProperty.all(Colors.grey.withOpacity(0.9)),
         foregroundColor: WidgetStateProperty.all(Colors.white),
         overlayColor: WidgetStateProperty.all(Colors.grey),
         shape: WidgetStateProperty.all(const RoundedRectangleBorder(

--- a/lib/src/ui/widgets/room/chat_toggle.dart
+++ b/lib/src/ui/widgets/room/chat_toggle.dart
@@ -36,7 +36,7 @@ class ChatToggleWidget extends StatelessWidget {
     return ElevatedButton(
       style: ButtonStyle(
         backgroundColor: WidgetStateProperty.all(
-            isChatOpen ? LKColors.lkBlue : Colors.grey.withValues(alpha: 0.9)),
+            isChatOpen ? LKColors.lkBlue : Colors.grey.withOpacity(0.9)),
         foregroundColor: WidgetStateProperty.all(Colors.white),
         overlayColor: WidgetStateProperty.all(
             isChatOpen ? LKColors.lkLightBlue : Colors.grey),

--- a/lib/src/ui/widgets/room/disconnect_button.dart
+++ b/lib/src/ui/widgets/room/disconnect_button.dart
@@ -42,7 +42,7 @@ class DisconnectButtonWidget extends StatelessWidget {
     return ElevatedButton(
       style: ButtonStyle(
         backgroundColor: WidgetStateProperty.all(
-            connected ? Colors.red : Colors.grey.withValues(alpha: 0.9)),
+            connected ? Colors.red : Colors.grey.withOpacity(0.9)),
         foregroundColor: WidgetStateProperty.all(Colors.white),
         overlayColor:
             WidgetStateProperty.all(connected ? Colors.redAccent : Colors.grey),

--- a/lib/src/ui/widgets/room/media_device_select_button.dart
+++ b/lib/src/ui/widgets/room/media_device_select_button.dart
@@ -55,7 +55,7 @@ class MediaDeviceSelectWidget extends StatelessWidget {
         style: ButtonStyle(
           backgroundColor: WidgetStateProperty.all(deviceIsOpened
               ? LKColors.lkBlue
-              : Colors.grey.withValues(alpha: 0.9)),
+              : Colors.grey.withOpacity(0.9)),
           foregroundColor: WidgetStateProperty.all(Colors.white),
           overlayColor: WidgetStateProperty.all(
               deviceIsOpened ? LKColors.lkLightBlue : Colors.grey),
@@ -93,7 +93,7 @@ class MediaDeviceSelectWidget extends StatelessWidget {
             0, ((deviceList.isNotEmpty ? deviceList.length : 1) * -55.0)),
         style: ButtonStyle(
           backgroundColor:
-              WidgetStateProperty.all(Colors.grey.withValues(alpha: 0.9)),
+              WidgetStateProperty.all(Colors.grey.withOpacity(0.9)),
           foregroundColor: WidgetStateProperty.all(Colors.white),
           overlayColor: WidgetStateProperty.all(Colors.grey),
           elevation: WidgetStateProperty.all(20),

--- a/lib/src/ui/widgets/room/media_device_select_button.dart
+++ b/lib/src/ui/widgets/room/media_device_select_button.dart
@@ -53,9 +53,8 @@ class MediaDeviceSelectWidget extends StatelessWidget {
     return Row(mainAxisSize: MainAxisSize.min, children: [
       ElevatedButton(
         style: ButtonStyle(
-          backgroundColor: WidgetStateProperty.all(deviceIsOpened
-              ? LKColors.lkBlue
-              : Colors.grey.withOpacity(0.9)),
+          backgroundColor: WidgetStateProperty.all(
+              deviceIsOpened ? LKColors.lkBlue : Colors.grey.withOpacity(0.9)),
           foregroundColor: WidgetStateProperty.all(Colors.white),
           overlayColor: WidgetStateProperty.all(
               deviceIsOpened ? LKColors.lkLightBlue : Colors.grey),

--- a/lib/src/ui/widgets/room/screenshare_toggle.dart
+++ b/lib/src/ui/widgets/room/screenshare_toggle.dart
@@ -42,7 +42,7 @@ class ScreenShareToggleWidget extends StatelessWidget {
       style: ButtonStyle(
         backgroundColor: WidgetStateProperty.all(screenShareEnabled
             ? LKColors.lkBlue
-            : Colors.grey.withValues(alpha: 0.9)),
+            : Colors.grey.withOpacity(0.9)),
         foregroundColor: WidgetStateProperty.all(Colors.white),
         overlayColor: WidgetStateProperty.all(
             screenShareEnabled ? LKColors.lkLightBlue : Colors.grey),

--- a/lib/src/ui/widgets/room/speaker_switch_button.dart
+++ b/lib/src/ui/widgets/room/speaker_switch_button.dart
@@ -31,7 +31,7 @@ class SpeakerSwitchButton extends StatelessWidget {
     return ElevatedButton(
       style: ButtonStyle(
         backgroundColor:
-            WidgetStateProperty.all(Colors.grey.withValues(alpha: 0.9)),
+            WidgetStateProperty.all(Colors.grey.withOpacity(0.9)),
         foregroundColor: WidgetStateProperty.all(Colors.white),
         overlayColor: WidgetStateProperty.all(Colors.grey),
         shape: WidgetStateProperty.all(const RoundedRectangleBorder(

--- a/lib/src/ui/widgets/room/speaker_switch_button.dart
+++ b/lib/src/ui/widgets/room/speaker_switch_button.dart
@@ -30,8 +30,7 @@ class SpeakerSwitchButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       style: ButtonStyle(
-        backgroundColor:
-            WidgetStateProperty.all(Colors.grey.withOpacity(0.9)),
+        backgroundColor: WidgetStateProperty.all(Colors.grey.withOpacity(0.9)),
         foregroundColor: WidgetStateProperty.all(Colors.white),
         overlayColor: WidgetStateProperty.all(Colors.grey),
         shape: WidgetStateProperty.all(const RoundedRectangleBorder(

--- a/lib/src/ui/widgets/theme.dart
+++ b/lib/src/ui/widgets/theme.dart
@@ -60,7 +60,7 @@ class LiveKitTheme {
             // backgroundColor: WidgetStateProperty.all<Color>(accentColor),
             backgroundColor: WidgetStateProperty.resolveWith((states) {
               if (states.contains(WidgetState.disabled)) {
-                return accentColor.withValues(alpha: 0.5);
+                return accentColor.withOpacity(0.5);
               }
               return accentColor;
             }),
@@ -75,13 +75,13 @@ class LiveKitTheme {
             if (states.contains(WidgetState.selected)) {
               return accentColor;
             }
-            return accentColor.withValues(alpha: 0.3);
+            return accentColor.withOpacity(0.3);
           }),
           thumbColor: WidgetStateProperty.resolveWith((states) {
             if (states.contains(WidgetState.selected)) {
               return Colors.white;
             }
-            return Colors.white.withValues(alpha: 0.3);
+            return Colors.white.withOpacity(0.3);
           }),
         ),
         dialogTheme: DialogTheme(
@@ -103,7 +103,7 @@ class LiveKitTheme {
             color: LKColors.lkBlue,
           ),
           hintStyle: TextStyle(
-            color: LKColors.lkBlue.withValues(alpha: .5),
+            color: LKColors.lkBlue.withOpacity(0.5),
           ),
           enabledBorder: InputBorder.none,
           focusedBorder: InputBorder.none,

--- a/lib/src/ui/widgets/track/track_stats_widget.dart
+++ b/lib/src/ui/widgets/track/track_stats_widget.dart
@@ -26,7 +26,7 @@ class TrackStatsWidget extends StatelessWidget {
               children: [
                 trackCtx.showStatistics && stats.isNotEmpty
                     ? Container(
-                        color: Colors.black.withValues(alpha: 0.3),
+                        color: Colors.black.withOpacity(0.3),
                         padding: const EdgeInsets.symmetric(
                           vertical: 8,
                           horizontal: 8,


### PR DESCRIPTION
for some reason the default behavior of `flutter analyze` is to treat "info" warnings as fatal, even though the default behavior of `dart analyze` is not.  it's too restrictive for info-level warnings to be fatal to CI, as deprecation notices go here and there are legitimate reasons to keep deprecated APIs to support older versions of Flutter.

To test this change, I reverted #8