### PR TITLE
add trackmuted to roomcontext listener

### DIFF
--- a/lib/src/context/room_context.dart
+++ b/lib/src/context/room_context.dart
@@ -134,6 +134,16 @@ class RoomContext extends ChangeNotifier with ChatContextMixin {
         Debug.event(
             'RoomContext: LocalTrackUnpublishedEvent track = ${event.publication.sid}');
         _buildParticipants();
+      })
+      ..on<TrackMutedEvent>((event) {
+        Debug.event(
+            'RoomContext: TrackMutedEvent $roomName participant = ${event.participant.identity} track = ${event.publication.sid}');
+        _buildParticipants();
+      })
+      ..on<TrackUnmutedEvent>((event) {
+        Debug.event(
+            'RoomContext: TrackUnmutedEvent $roomName participant = ${event.participant.identity} track = ${event.publication.sid}');
+        _buildParticipants();
       });
 
     if (connect && url != null && token != null) {

--- a/lib/src/ui/widgets/track/audio_visualizer_widget.dart
+++ b/lib/src/ui/widgets/track/audio_visualizer_widget.dart
@@ -92,22 +92,13 @@ class _SoundWaveformWidgetState extends State<SoundWaveformWidget>
 
   void _startVisualizer(AudioTrack? track) async {
     _listener = track?.createListener();
-    _listener
-      ?..on<AudioVisualizerEvent>((e) {
-        if (mounted) {
-          setState(() {
-            samples =
-                e.event.map((e) => ((e as num) * 100).toDouble()).toList();
-          });
-        }
-      })
-      ..on<TrackMutedEvent>((e) {
-        if (mounted) {
-          setState(() {
-            samples = List.filled(samples.length, 0);
-          });
-        }
-      });
+    _listener?.on<AudioVisualizerEvent>((e) {
+      if (mounted) {
+        setState(() {
+          samples = e.event.map((e) => ((e as num) * 100).toDouble()).toList();
+        });
+      }
+    });
   }
 
   void _stopVisualizer() async {


### PR DESCRIPTION
The default behavior of setMicrophoneEnabled(false) is to simply mute it, which wasn't triggering RoomContext updates on the isMicrophoneEnabled property.

I also removed the muted listener in the visualizer, which didn't work because TrackMutedEvent is fired on Room and Participant and not on Track. It was also unnecessary, https://github.com/livekit/client-sdk-flutter/pull/701 is a simpler solution for the issue.