### PR TITLE
remove the early return statement in iOS screen sharing

### DIFF
--- a/lib/src/context/media_device_context.dart
+++ b/lib/src/context/media_device_context.dart
@@ -261,7 +261,6 @@ class MediaDeviceContext extends ChangeNotifier {
         ),
       );
       await _room?.localParticipant?.publishVideoTrack(track);
-      return;
     }
 
     if (lkPlatformIsWebMobile()) {


### PR DESCRIPTION
remove the early return statement in iOS screen sharing