### PR TITLE
Fix compile issue with Flutter 3.32

### DIFF
--- a/lib/src/ui/widgets/theme.dart
+++ b/lib/src/ui/widgets/theme.dart
@@ -84,7 +84,7 @@ class LiveKitTheme {
             return Colors.white.withValues(alpha: 0.3);
           }),
         ),
-        dialogTheme: DialogTheme(
+        dialogTheme: DialogThemeData(
           backgroundColor: cardColor,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),


### PR DESCRIPTION
In new versions of flutter, `ThemeData`.`dialogTheme` is now a `DialogThemeData`.
https://docs.flutter.dev/release/breaking-changes/material-theme-system-updates

