### PR TITLE
Optimize transcription context

### DIFF
--- a/lib/src/context/room_context.dart
+++ b/lib/src/context/room_context.dart
@@ -79,7 +79,7 @@ class RoomContext extends ChangeNotifier
         Debug.event('RoomContext: RoomDisconnectedEvent $roomName');
         _connectionState = _room.connectionState;
         chatContextSetup(null, null);
-        transcriptionContextSetup(null);
+        transcriptionContextCleanUp();
         _connected = false;
         _participants.clear();
         onDisconnected?.call();


### PR DESCRIPTION
Provider / Selector not triggering update since identical() always returns true when comparing `transcriptions`.